### PR TITLE
Add class to flare counts, fixed screen point issue, Made X&Y names configurable

### DIFF
--- a/ncam/FlareClusterLayer.js
+++ b/ncam/FlareClusterLayer.js
@@ -708,6 +708,7 @@
             var textShape = groupShape.createText({ x: shapeCenter.x, y: shapeCenter.y + (this.textSymbol.font.size / 2 - 2), text: cluster.clusterCount, align: 'middle' })
                             .setFont({ size: this.textSymbol.font.size, family: this.textSymbol.font.family, weight: this.textSymbol.font.weight })
                             .setFill(this.textSymbol.color);
+            textShape.rawNode.setAttribute("class", "flare-text-counts");
             textShape.rawNode.setAttribute("pointer-events", "none"); //remove pointer events from text
             groupShape.add(textShape);
             cluster.textShape = textShape;
@@ -909,7 +910,14 @@
                 pt.x = fo.center.x;
                 pt.y = fo.center.y;
                 var screenPoint = pt.matrixTransform(matrix);
-                var sp = new ScreenPoint(screenPoint.x, screenPoint.y);
+
+                //ScreenPoint needs to be relative to the top-left corner of the map control.
+                //The matrixTransform on pt gives us a point based on the screen coordinate system.
+                //Therefore if the map has a top offset applied to it the fo object will appear in 
+                //an incorrect spot on the map.  We must apply the offset to both the x and y points
+                //to ensure the point is relative to the map control.
+                var offsets = this.surface.rawNode.getBoundingClientRect();
+                var sp = new ScreenPoint(screenPoint.x - offsets.left, screenPoint.y - offsets.top);
                 fo.mapPoint = this.map.toMap(sp);
 
                 var attributes = fo.singleData ? lang.clone(fo.singleData) : {};

--- a/ncam/FlareClusterLayer.js
+++ b/ncam/FlareClusterLayer.js
@@ -1,3 +1,4 @@
+//https://github.com/nickcam/FlareClusterLayer
 define([
   "dojo/_base/declare",
   "dojo/_base/lang",
@@ -216,7 +217,7 @@ define([
                 this.map.infoWindow.cluster = this.activeCluster;
 
                 //reset the geometry of the flare feature in the info window to be the actual location of the flared object, not the location of the flare graphic.
-                var p = webMercatorUtils.geographicToWebMercator(new Point(flareObject.singleData.x, flareObject.singleData.y, this.spatialRef));
+                var p = webMercatorUtils.geographicToWebMercator(new Point(flareObject.singleData[this.xPropertyName], flareObject.singleData[this.yPropertyName], this.spatialRef));
                 this.map.infoWindow.features[0].geometry = p;
                 this.map.infoWindow.show(sp);
 
@@ -227,7 +228,8 @@ define([
         //Each object passed in must contain an x and y property. 
         //Data should also contain whatever property is set in singleFlareTooltipProperty, so the flare tooltip has something to display for summary flares if needed
         add: function (p) {
-
+           
+             
             // if passed a graphic, just use the base GraphicsLayer's add method
             if (p.declaredClass) {
                 this.inherited(arguments);
@@ -1154,7 +1156,7 @@ define([
             //return the graphic from the obj which could be a single or cluster object
             for (var i = 0, len = this.graphics.length; i < len; i++) {
                 var g = this.graphics[i];
-                if (g.attributes.x === obj[this.xPropertyName] && g.attributes.y === obj[this.yPropertyName]) {
+                if (g.attributes[this.xPropertyName] === obj[this.xPropertyName] && g.attributes[this.yPropertyName] === obj[this.yPropertyName]) {
                     return g;
                 }
             }
@@ -1185,7 +1187,7 @@ define([
             //return the obj which could be a single or cluster object, based on the graphic
             for (var i = 0, len = this.flareObjects.length; i < len; i++) {
                 var fl = this.flareObjects[i];
-                if (fl.singleData && (fl.singleData.x === graphic.attributes.x && fl.singleData.y === graphic.attributes.y)) {
+                if (fl.singleData && (fl.singleData[this.xPropertyName] === graphic.attributes[this.xPropertyName] && fl.singleData[this.yPropertyName] === graphic.attributes[this.yPropertyName])) {
                     return fl;
                 }
 
@@ -1249,3 +1251,4 @@ define([
         //#endregion
     });
 });
+

--- a/ncam/FlareClusterLayer.js
+++ b/ncam/FlareClusterLayer.js
@@ -614,7 +614,7 @@
         _createSingle: function (single) {
             this.singles.push(single);
             delete single.graphic;
-            var point = new Point(single.x, single.y, this.spatialRef);
+            var point = new Point(single[this.xPropertyName], single[this.yPropertyName], this.spatialRef);
             var attributes = lang.clone(single);
             var graphic = new Graphic(point, null, attributes, null);
             single.graphic = graphic;

--- a/ncam/FlareClusterLayer.js
+++ b/ncam/FlareClusterLayer.js
@@ -1,4 +1,4 @@
-﻿define([
+define([
   "dojo/_base/declare",
   "dojo/_base/lang",
   "dojo/_base/array",


### PR DESCRIPTION
A class flare-text-counts was added to the flare counts text node to
allow for additional styling.

Fixed issue with the ScreenPoint not taking the top and left offsets
into account if the map is placed in a div that is offset.
